### PR TITLE
Generalize to handle token standards other than ERC20 (e.g. eosio)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@ The app provides "tap to pay" and "tap to top-up" functionality for our NFC wall
 
 https://citizenwallet.notion.site/Kiosk-manual-1d5b408be10b446b90ed5e53978dd02e
 
-## Standalone kiosk hardware I: 
-
-https://www.notion.so/citizenwallet/Citizen-wallet-POS-hardware-58a038ce3e234e67827b8612d1805fb7?pvs=4#228a3f65e4ec4e1ca85ac28f61f39cb4
-
-## Standalone kiosk hardware II: Fablab/RPi
-
-https://www.notion.so/citizenwallet/Citizen-wallet-POS-hardware-58a038ce3e234e67827b8612d1805fb7?pvs=4#457ca3692a344d148de615346a7af2d2
-
 ## Getting Started
 
 This project is a Flutter application.
@@ -24,14 +16,4 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
-
-## RPi build
-
-This build uses the flutter-pi embedder https://github.com/ardera/flutter-pi 
-Related code here https://github.com/chuck-h/rpi-kiosk/tree/flutter 
-
-```
-flutterpi_tool build --release
-scp -r ./build/flutter_assets/ <your_rpi_address>:/home/pie/rpi-kiosk/pos
-```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 Mobile app that serves as a Point of Sale application/Kiosk for our NFC wallets. 
 The app provides "tap to pay" and "tap to top-up" functionality for our NFC wallets.
 
+https://citizenwallet.notion.site/Kiosk-manual-1d5b408be10b446b90ed5e53978dd02e
+
+## Standalone kiosk hardware I: 
+
+https://www.notion.so/citizenwallet/Citizen-wallet-POS-hardware-58a038ce3e234e67827b8612d1805fb7?pvs=4#228a3f65e4ec4e1ca85ac28f61f39cb4
+
+## Standalone kiosk hardware II: Fablab/RPi
+
+https://www.notion.so/citizenwallet/Citizen-wallet-POS-hardware-58a038ce3e234e67827b8612d1805fb7?pvs=4#457ca3692a344d148de615346a7af2d2
 
 ## Getting Started
 
@@ -15,3 +24,14 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## RPi build
+
+This build uses the flutter-pi embedder https://github.com/ardera/flutter-pi 
+Related code here https://github.com/chuck-h/rpi-kiosk/tree/flutter 
+
+```
+flutterpi_tool build --release
+scp -r ./build/flutter_assets/ <your_rpi_address>:/home/pie/rpi-kiosk/pos
+```
+

--- a/android/keystore.properties
+++ b/android/keystore.properties
@@ -1,0 +1,5 @@
+storePassword=dummy
+keyPassword=dummy
+keyAlias=dummy
+storeFile=dummy
+

--- a/assets/config/v3/communities.test.json
+++ b/assets/config/v3/communities.test.json
@@ -1359,5 +1359,33 @@
       }
     ],
     "version": 1
-  }
+  },
+  {
+    "community": {
+      "name": "SEEDS",
+      "description": "This is a community for Chuck",
+      "url": "https://joinseeds.earth",
+      "alias": "chuck.citizenwallet.xyz",
+      "custom_domain": "",
+      "logo": "https://raw.githubusercontent.com/JoinSEEDS/seeds_light_wallet/master/assets/images/seeds_logo.svg",
+      "theme": {
+        "primary": "#00c800"
+      }
+    },
+    "token": {
+      "standard": "eosio",
+      "name": "Seeds",
+      "address": "token.seeds",
+      "symbol": "SEEDS",
+      "decimals": 4
+    },
+    "scan": {
+      "url": "https://explorer.telos.net/network",
+      "name": "Telos zero"
+    },
+    "node": {
+      "url": "https://mainnet.telos.net"
+    },
+    "version": 1
+  }  
 ]

--- a/assets/config/v3/communities.test.json
+++ b/assets/config/v3/communities.test.json
@@ -1384,7 +1384,8 @@
       "name": "Telos zero"
     },
     "node": {
-      "url": "https://mainnet.telos.net"
+      "url": "https://mainnet.telos.net",
+      "invoice_url": "https://cc42.xyz/invoice"
     },
     "version": 1
   }  

--- a/lib/router/bottom_tabs.dart
+++ b/lib/router/bottom_tabs.dart
@@ -83,7 +83,8 @@ class CustomBottomAppBar extends StatelessWidget {
                 enabled: !redeeming,
                 offset: const Offset(0, 40),
                 itemBuilder: (BuildContext context) => configs
-                    .where((c) => c.cards != null)
+                    .where((c) => c.cards != null
+                                  || c.token.standard == "eosio")
                     .map<PopupMenuEntry<Config>>(
                       (c) => PopupMenuItem<Config>(
                         value: c,

--- a/lib/screens/pos/screen.dart
+++ b/lib/screens/pos/screen.dart
@@ -89,85 +89,87 @@ class POSScreenState extends State<POSScreen>
       return;
     }
 
-    final deepLinkUrl = dotenv.env['WALLET_DEEPLINK_URL'];
-    if (deepLinkUrl == null) {
-      return;
-    }
+    if (config.token.standard == "erc20") {
+      final deepLinkUrl = dotenv.env['WALLET_DEEPLINK_URL'];
+      if (deepLinkUrl == null) {
+        return;
+      }
 
-    _scanLogic.listenToBalance();
+      _scanLogic.listenToBalance();
 
-    await showModalBottomSheet<void>(
-      context: context,
-      builder: (modalContext) {
-        final vendorAddress = modalContext.watch<ScanState>().vendorAddress;
-        final vendorBalance = modalContext.watch<ScanState>().vendorBalance;
+      await showModalBottomSheet<void>(
+        context: context,
+        builder: (modalContext) {
+          final vendorAddress = modalContext.watch<ScanState>().vendorAddress;
+          final vendorBalance = modalContext.watch<ScanState>().vendorBalance;
 
-        String params =
-            '?address=$vendorAddress&alias=${config.community.alias}';
+          String params =
+              '?address=$vendorAddress&alias=${config.community.alias}';
 
-        params += '&amount=$amount';
-        params += '&message=$description';
+          params += '&amount=$amount';
+          params += '&message=$description';
 
-        final compressedParams = compress(params);
+          final compressedParams = compress(params);
 
-        final deepLink =
-            '$deepLinkUrl/#/?alias=${config.community.alias}&receiveParams=$compressedParams';
+          final deepLink =
+              '$deepLinkUrl/#/?alias=${config.community.alias}&receiveParams=$compressedParams';
 
-        return Container(
-          height: height,
-          width: width,
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              const Text(
-                'Scan to pay',
-                style: TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
+          return Container(
+            height: height,
+            width: width,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const Text(
+                  'Scan to pay',
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 16),
-              QR(
-                data: deepLink,
-                size: width - 120,
-              ),
-              const SizedBox(height: 16),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Text(
-                    '$amount ${config.token.symbol}',
-                    style: const TextStyle(
-                      fontSize: 22,
-                      fontWeight: FontWeight.normal,
+                const SizedBox(height: 16),
+                QR(
+                  data: deepLink,
+                  size: width - 120,
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Text(
+                      '$amount ${config.token.symbol}',
+                      style: const TextStyle(
+                        fontSize: 22,
+                        fontWeight: FontWeight.normal,
+                      ),
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Text(
-                    description,
-                    style: const TextStyle(
-                      fontSize: 22,
-                      fontWeight: FontWeight.normal,
+                  ],
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Text(
+                      description,
+                      style: const TextStyle(
+                        fontSize: 22,
+                        fontWeight: FontWeight.normal,
+                      ),
                     ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        );
-      },
-    );
+                  ],
+                ),
+              ],
+            ),
+          );
+        },
+      );
 
-    _scanLogic.stopListenToBalance();
+      _scanLogic.stopListenToBalance();
+    }
   }
 
   void handleScan(

--- a/lib/services/config/config.dart
+++ b/lib/services/config/config.dart
@@ -185,11 +185,13 @@ class NodeConfig {
   final int chainId;
   final String url;
   final String wsUrl;
+  String? invoiceUrl;
 
   NodeConfig({
     required this.chainId,
     required this.url,
     required this.wsUrl,
+    this.invoiceUrl
   });
 
   factory NodeConfig.fromJson(Map<String, dynamic> json) {
@@ -197,6 +199,7 @@ class NodeConfig {
       chainId: json['chain_id'] ?? 1,
       url: json['url'],
       wsUrl: json['ws_url'] ?? "",
+      invoiceUrl: json['invoice_url']
     );
   }
 
@@ -206,13 +209,14 @@ class NodeConfig {
       'chain_id': chainId,
       'url': url,
       'ws_url': wsUrl,
+      'invoice_url': invoiceUrl
     };
   }
 
   // to string
   @override
   String toString() {
-    return 'NodeConfig{chainId: $chainId url: $url, wsUrl: $wsUrl}';
+    return 'NodeConfig{chainId: $chainId url: $url, wsUrl: $wsUrl, invoiceUrl: $invoiceUrl}';
   }
 }
 

--- a/lib/services/config/config.dart
+++ b/lib/services/config/config.dart
@@ -196,7 +196,7 @@ class NodeConfig {
     return NodeConfig(
       chainId: json['chain_id'] ?? 1,
       url: json['url'],
-      wsUrl: json['ws_url'],
+      wsUrl: json['ws_url'] ?? "",
     );
   }
 
@@ -453,26 +453,26 @@ class Legacy4337Bundlers {
 
 class Config {
   final CommunityConfig community;
-  final ScanConfig scan;
-  final IndexerConfig indexer;
-  final IPFSConfig ipfs;
-  final NodeConfig node;
-  final ERC4337Config erc4337;
+  final ScanConfig? scan;
+  final IndexerConfig? indexer;
+  final IPFSConfig? ipfs;
+  final NodeConfig? node;
+  final ERC4337Config? erc4337;
   final TokenConfig token;
-  final ProfileConfig profile;
+  final ProfileConfig? profile;
   final CardsConfig? cards;
   final List<PluginConfig> plugins;
   final int version;
 
   Config({
     required this.community,
-    required this.scan,
-    required this.indexer,
-    required this.ipfs,
-    required this.node,
-    required this.erc4337,
+    this.scan,
+    this.indexer,
+    this.ipfs,
+    this.node,
+    this.erc4337,
     required this.token,
-    required this.profile,
+    this.profile,
     this.cards,
     required this.plugins,
     this.version = 0,
@@ -481,13 +481,13 @@ class Config {
   factory Config.fromJson(Map<String, dynamic> json) {
     return Config(
       community: CommunityConfig.fromJson(json['community']),
-      scan: ScanConfig.fromJson(json['scan']),
-      indexer: IndexerConfig.fromJson(json['indexer']),
-      ipfs: IPFSConfig.fromJson(json['ipfs']),
-      node: NodeConfig.fromJson(json['node']),
-      erc4337: ERC4337Config.fromJson(json['erc4337']),
+      scan: json['scan'] != null ? ScanConfig.fromJson(json['scan']) : null,
+      indexer: json['indexer'] != null ? IndexerConfig.fromJson(json['indexer']) : null,
+      ipfs: json['ipfs'] != null ? IPFSConfig.fromJson(json['ipfs']) : null,
+      node: json['node'] != null ? NodeConfig.fromJson(json['node']) : null,
+      erc4337: json['erc4337'] != null ? ERC4337Config.fromJson(json['erc4337']) : null,
       token: TokenConfig.fromJson(json['token']),
-      profile: ProfileConfig.fromJson(json['profile']),
+      profile: json['profile'] != null ? ProfileConfig.fromJson(json['profile']) : null,
       cards: json['cards'] != null ? CardsConfig.fromJson(json['cards']) : null,
       plugins: json['plugins'] != null
           ? (json['plugins'] as List)

--- a/lib/services/web3/service.dart
+++ b/lib/services/web3/service.dart
@@ -81,6 +81,7 @@ class Web3Service {
     String? entryPointAddress,
     String? tokenAddress,
     String? profileAddress,
+    [String? invoiceUrl]
   ) async {
     _tokenStandard = tokenStandard;
     if (_tokenStandard == "erc20") {
@@ -167,7 +168,9 @@ class Web3Service {
       );
 
       await _contractProfile!.init();
-    } // _tokenStandard erc20
+    } else if (_tokenStandard == "eosio") {
+      // TODO make API wrapper for invoiceUrl
+    }
   }
   Future<Uint8List> getCardHash(String serial, {bool local = true}) async {
     return _cardManager!.getCardHash(serial, local: local);
@@ -806,4 +809,5 @@ class Web3Service {
       rethrow;
     }
   }
+
 }

--- a/lib/services/web3/service.dart
+++ b/lib/services/web3/service.dart
@@ -41,146 +41,150 @@ class Web3Service {
   BigInt? _chainId;
 
   final String _indexerKey = 'x';
+  late String _tokenStandard;
 
   late Client _client;
   late String _url;
   late String _ipfsUrl;
   late Web3Client _ethClient;
 
-  late APIService _rpc;
-  late APIService _ipfs;
-  late APIService _indexer;
-  late APIService _indexerIPFS;
-  late APIService _bundlerRPC;
-  late APIService _paymasterRPC;
+  APIService? _rpc;
+  APIService? _ipfs;
+  APIService? _indexer;
+  APIService? _indexerIPFS;
+  APIService? _bundlerRPC;
+  APIService? _paymasterRPC;
 
-  late EthereumAddress _account;
-  late EthPrivateKey _credentials;
+  EthereumAddress? _account;
+  EthPrivateKey? _credentials;
 
-  late ERC20Contract _contractToken;
-  late CardManagerContract _cardManager;
-  late AccountFactoryContract _accountFactory;
-  late TokenEntryPointContract _entryPoint;
-  late AccountContract _contractAccount;
-  late ProfileContract _contractProfile;
+  ERC20Contract? _contractToken;
+  CardManagerContract? _cardManager;
+  AccountFactoryContract? _accountFactory;
+  TokenEntryPointContract? _entryPoint;
+  AccountContract? _contractAccount;
+  ProfileContract? _contractProfile;
 
-  late EIP1559GasPriceEstimator _gasPriceEstimator;
+  EIP1559GasPriceEstimator? _gasPriceEstimator;
 
   Future<void> init(
-    String rpcUrl,
-    String ipfsUrl,
-    String bundlerUrl,
-    String indexerUrl,
-    String indexerIPFSUrl,
-    String paymasterUrl,
-    String paymasterAddress,
-    String cardManagerAddress,
-    String accountFactoryAddress,
-    String entryPointAddress,
-    String tokenAddress,
-    String profileAddress,
+    String tokenStandard,
+    String? rpcUrl,
+    String? ipfsUrl,
+    String? bundlerUrl,
+    String? indexerUrl,
+    String? indexerIPFSUrl,
+    String? paymasterUrl,
+    String? paymasterAddress,
+    String? cardManagerAddress,
+    String? accountFactoryAddress,
+    String? entryPointAddress,
+    String? tokenAddress,
+    String? profileAddress,
   ) async {
-    _url = rpcUrl;
-    _ipfsUrl = ipfsUrl;
-    _ethClient = Web3Client(_url, _client);
+    _tokenStandard = tokenStandard;
+    if (_tokenStandard == "erc20") {
+      _url = rpcUrl!;
+      _ethClient = Web3Client(_url, _client);
+      _rpc = APIService(baseURL: _url);
+      if (ipfsUrl != null) {
+        _ipfsUrl = ipfsUrl;
+        _ipfs = APIService(baseURL: ipfsUrl);        
+      }
+      _indexer = indexerUrl != null ? APIService(baseURL: indexerUrl) : null;
+      _indexerIPFS = APIService(baseURL: indexerIPFSUrl!);
+      _bundlerRPC = APIService(baseURL: '$bundlerUrl/$paymasterAddress');
+      _paymasterRPC = APIService(baseURL: '$paymasterUrl/$paymasterAddress');
 
-    _rpc = APIService(baseURL: rpcUrl);
-    _ipfs = APIService(baseURL: ipfsUrl);
+      _gasPriceEstimator = EIP1559GasPriceEstimator(
+        _rpc!,
+        _ethClient,
+      );
 
-    _indexer = APIService(baseURL: indexerUrl);
-    _indexerIPFS = APIService(baseURL: indexerIPFSUrl);
-    _bundlerRPC = APIService(baseURL: '$bundlerUrl/$paymasterAddress');
-    _paymasterRPC = APIService(baseURL: '$paymasterUrl/$paymasterAddress');
+      _chainId = await _ethClient.getChainId();
 
-    _gasPriceEstimator = EIP1559GasPriceEstimator(
-      _rpc,
-      _ethClient,
-    );
+      if (_chainId == null) {
+        throw Exception('Could not get chain id');
+      }
 
-    _chainId = await _ethClient.getChainId();
+      final key = _prefs.key;
+      if (key == null) {
+        final credentials = EthPrivateKey.createRandom(Random.secure());
 
-    if (_chainId == null) {
-      throw Exception('Could not get chain id');
-    }
+        await _prefs.setKey(bytesToHex(credentials.privateKey));
 
-    final key = _prefs.key;
-    if (key == null) {
-      final credentials = EthPrivateKey.createRandom(Random.secure());
+        _credentials = credentials;
+      } else {
+        _credentials = EthPrivateKey.fromHex(key);
+      }
 
-      await _prefs.setKey(bytesToHex(credentials.privateKey));
+      _contractToken = ERC20Contract(
+        _chainId!.toInt(),
+        _ethClient,
+        tokenAddress!,
+      );
 
-      _credentials = credentials;
-    } else {
-      _credentials = EthPrivateKey.fromHex(key);
-    }
+      await _contractToken!.init();
 
-    _contractToken = ERC20Contract(
-      _chainId!.toInt(),
-      _ethClient,
-      tokenAddress,
-    );
+      _cardManager = CardManagerContract(
+        _chainId!.toInt(),
+        _ethClient,
+        cardManagerAddress!,
+      );
 
-    await _contractToken.init();
+      await _cardManager!.init();
 
-    _cardManager = CardManagerContract(
-      _chainId!.toInt(),
-      _ethClient,
-      cardManagerAddress,
-    );
+      _accountFactory = AccountFactoryContract(
+        _chainId!.toInt(),
+        _ethClient,
+        accountFactoryAddress!,
+      );
 
-    await _cardManager.init();
+      await _accountFactory!.init();
 
-    _accountFactory = AccountFactoryContract(
-      _chainId!.toInt(),
-      _ethClient,
-      accountFactoryAddress,
-    );
+      _account = await _accountFactory!.getAddress(_credentials!.address.hexEip55);
 
-    await _accountFactory.init();
+      _entryPoint = TokenEntryPointContract(
+        _chainId!.toInt(),
+        _ethClient,
+        entryPointAddress!,
+      );
 
-    _account = await _accountFactory.getAddress(_credentials.address.hexEip55);
+      await _entryPoint!.init();
 
-    _entryPoint = TokenEntryPointContract(
-      _chainId!.toInt(),
-      _ethClient,
-      entryPointAddress,
-    );
+      _contractAccount = AccountContract(
+        _chainId!.toInt(),
+        _ethClient,
+        _account!.hexEip55,
+      );
 
-    await _entryPoint.init();
+      await _contractAccount!.init();
 
-    _contractAccount = AccountContract(
-      _chainId!.toInt(),
-      _ethClient,
-      _account.hexEip55,
-    );
+      _contractProfile = ProfileContract(
+        _chainId!.toInt(),
+        _ethClient,
+        profileAddress!,
+      );
 
-    await _contractAccount.init();
-
-    _contractProfile = ProfileContract(
-      _chainId!.toInt(),
-      _ethClient,
-      profileAddress,
-    );
-
-    await _contractProfile.init();
+      await _contractProfile!.init();
+    } // _tokenStandard erc20
   }
-
   Future<Uint8List> getCardHash(String serial, {bool local = true}) async {
-    return _cardManager.getCardHash(serial, local: local);
+    return _cardManager!.getCardHash(serial, local: local);
   }
 
   Future<EthereumAddress> getCardAddress(Uint8List hash) async {
-    return _cardManager.getCardAddress(hash);
+    return _cardManager!.getCardAddress(hash);
   }
 
-  EthereumAddress get account => _account;
-  EthereumAddress get tokenAddress => _contractToken.rcontract.address;
-  EthereumAddress get entrypointAddress => _entryPoint.rcontract.address;
-  EthereumAddress get cardManagerAddress => _cardManager.rcontract.address;
-  String get profileAddress => _contractProfile.addr;
+  EthereumAddress get account => _account!;
+  EthereumAddress get tokenAddress => _contractToken!.rcontract.address;
+  EthereumAddress get entrypointAddress => _entryPoint!.rcontract.address;
+  EthereumAddress get cardManagerAddress => _cardManager!.rcontract.address;
+  String get profileAddress => _contractProfile!.addr;
 
   Future<BigInt> getNonce(String addr) async {
-    return _entryPoint.getNonce(addr);
+    return _entryPoint!.getNonce(addr);
   }
 
   /// check if an account exists
@@ -188,9 +192,9 @@ class Web3Service {
     String? account,
   }) async {
     try {
-      final url = '/accounts/${account ?? _account.hexEip55}/exists';
+      final url = '/accounts/${account ?? _account!.hexEip55}/exists';
 
-      await _indexer.get(
+      await _indexer!.get(
         url: url,
         headers: {
           'Authorization': 'Bearer $_indexerKey',
@@ -204,7 +208,7 @@ class Web3Service {
   }
 
   Future<BigInt> getBalance(String addr) async {
-    return _contractToken.getBalance(addr);
+    return _contractToken!.getBalance(addr);
   }
 
   /// create an account
@@ -217,12 +221,12 @@ class Web3Service {
         return true;
       }
 
-      final calldata = _contractAccount.transferOwnershipCallData(
-        _credentials.address.hexEip55,
+      final calldata = _contractAccount!.transferOwnershipCallData(
+        _credentials!.address.hexEip55,
       );
 
       final (_, userop) = await prepareUserop(
-        [_account.hexEip55],
+        [_account!.hexEip55],
         [calldata],
       );
 
@@ -251,7 +255,7 @@ class Web3Service {
     required String fileType,
   }) async {
     try {
-      final url = '/profiles/v2/$profileAddress/${_account.hexEip55}';
+      final url = '/profiles/v2/$profileAddress/${_account!.hexEip55}';
 
       final json = jsonEncode(
         profile.toJson(),
@@ -260,24 +264,24 @@ class Web3Service {
       final body = SignedRequest(convertBytesToUint8List(utf8.encode(json)));
 
       final sig = await compute(
-          generateSignature, (jsonEncode(body.toJson()), _credentials));
+          generateSignature, (jsonEncode(body.toJson()), _credentials!));
 
-      final resp = await _indexerIPFS.filePut(
+      final resp = await _indexerIPFS!.filePut(
         url: url,
         file: image,
         fileType: fileType,
         headers: {
           'Authorization': 'Bearer $_indexerKey',
           'X-Signature': sig,
-          'X-Address': _account.hexEip55,
+          'X-Address': _account!.hexEip55,
         },
         body: body.toJson(),
       );
 
       final String profileUrl = resp['object']['ipfs_url'];
 
-      final calldata = _contractProfile.setCallData(
-          _account.hexEip55, profile.username, profileUrl);
+      final calldata = _contractProfile!.setCallData(
+          _account!.hexEip55, profile.username, profileUrl);
 
       final (_, userop) = await prepareUserop([profileAddress], [calldata]);
 
@@ -300,7 +304,7 @@ class Web3Service {
   /// update profile data
   Future<String?> updateProfile(ProfileV1 profile) async {
     try {
-      final url = '/profiles/v2/$profileAddress/${_account.hexEip55}';
+      final url = '/profiles/v2/$profileAddress/${_account!.hexEip55}';
 
       final json = jsonEncode(
         profile.toJson(),
@@ -309,22 +313,22 @@ class Web3Service {
       final body = SignedRequest(convertBytesToUint8List(utf8.encode(json)));
 
       final sig = await compute(
-          generateSignature, (jsonEncode(body.toJson()), _credentials));
+          generateSignature, (jsonEncode(body.toJson()), _credentials!));
 
-      final resp = await _indexerIPFS.patch(
+      final resp = await _indexerIPFS!.patch(
         url: url,
         headers: {
           'Authorization': 'Bearer $_indexerKey',
           'X-Signature': sig,
-          'X-Address': _account.hexEip55,
+          'X-Address': _account!.hexEip55,
         },
         body: body.toJson(),
       );
 
       final String profileUrl = resp['object']['ipfs_url'];
 
-      final calldata = _contractProfile.setCallData(
-          _account.hexEip55, profile.username, profileUrl);
+      final calldata = _contractProfile!.setCallData(
+          _account!.hexEip55, profile.username, profileUrl);
 
       final (_, userop) = await prepareUserop([profileAddress], [calldata]);
 
@@ -347,11 +351,11 @@ class Web3Service {
   /// set profile data
   Future<bool> unpinCurrentProfile() async {
     try {
-      final url = '/profiles/v2/$profileAddress/${_account.hexEip55}';
+      final url = '/profiles/v2/$profileAddress/${_account!.hexEip55}';
 
       final encoded = jsonEncode(
         {
-          'account': _account.hexEip55,
+          'account': _account!.hexEip55,
           'date': DateTime.now().toUtc().toIso8601String(),
         },
       );
@@ -359,14 +363,14 @@ class Web3Service {
       final body = SignedRequest(convertStringToUint8List(encoded));
 
       final sig = await compute(
-          generateSignature, (jsonEncode(body.toJson()), _credentials));
+          generateSignature, (jsonEncode(body.toJson()), _credentials!));
 
-      await _indexerIPFS.delete(
+      await _indexerIPFS!.delete(
         url: url,
         headers: {
           'Authorization': 'Bearer $_indexerKey',
           'X-Signature': sig,
-          'X-Address': _account.hexEip55,
+          'X-Address': _account!.hexEip55,
         },
         body: body.toJson(),
       );
@@ -380,9 +384,9 @@ class Web3Service {
   /// get profile data
   Future<ProfileV1?> getProfile(String addr) async {
     try {
-      final url = await _contractProfile.getURL(addr);
+      final url = await _contractProfile!.getURL(addr);
 
-      final profileData = await _ipfs.get(url: '/$url');
+      final profileData = await _ipfs!.get(url: '/$url');
 
       final profile = ProfileV1.fromJson(profileData);
 
@@ -399,7 +403,7 @@ class Web3Service {
   /// get profile data
   Future<ProfileV1?> getProfileFromUrl(String url) async {
     try {
-      final profileData = await _ipfs.get(url: '/$url');
+      final profileData = await _ipfs!.get(url: '/$url');
 
       final profile = ProfileV1.fromJson(profileData);
 
@@ -416,9 +420,9 @@ class Web3Service {
   /// get profile data by username
   Future<ProfileV1?> getProfileByUsername(String username) async {
     try {
-      final url = await _contractProfile.getURLFromUsername(username);
+      final url = await _contractProfile!.getURLFromUsername(username);
 
-      final profileData = await _ipfs.get(url: '/$url');
+      final profileData = await _ipfs!.get(url: '/$url');
 
       final profile = ProfileV1.fromJson(profileData);
 
@@ -435,7 +439,7 @@ class Web3Service {
   /// profileExists checks whether there is a profile for this username
   Future<bool> profileExists(String username) async {
     try {
-      final url = await _contractProfile.getURLFromUsername(username);
+      final url = await _contractProfile!.getURLFromUsername(username);
 
       return url != '';
     } catch (exception) {
@@ -450,7 +454,7 @@ class Web3Service {
     String to,
     BigInt amount,
   ) {
-    return _contractToken.transferCallData(
+    return _contractToken!.transferCallData(
       to,
       amount,
     );
@@ -461,10 +465,10 @@ class Web3Service {
     Uint8List hash,
     BigInt amount,
   ) {
-    return _cardManager.withdrawCallData(
+    return _cardManager!.withdrawCallData(
       hash,
-      _contractToken.addr,
-      _account.hexEip55,
+      _contractToken!.addr,
+      _account!.hexEip55,
       amount,
     );
   }
@@ -473,7 +477,7 @@ class Web3Service {
   Uint8List createCardCallData(
     Uint8List cardHash,
   ) {
-    return _cardManager.createAccountCallData(cardHash);
+    return _cardManager!.createAccountCallData(cardHash);
   }
 
   /// given a tx hash, waits for the tx to be mined
@@ -512,7 +516,7 @@ class Web3Service {
     SUJSONRPCRequest body, {
     bool legacy = false,
   }) async {
-    final rawResponse = await _paymasterRPC.post(
+    final rawResponse = await _paymasterRPC!.post(
       body: body,
     );
 
@@ -611,7 +615,7 @@ class Web3Service {
       List<String> dest, List<Uint8List> calldata) async {
     try {
       EthereumAddress acc =
-          await _accountFactory.getAddress(_credentials.address.hexEip55);
+          await _accountFactory!.getAddress(_credentials!.address.hexEip55);
 
       // instantiate user op with default values
       final userop = UserOp.defaultUserOp();
@@ -620,13 +624,13 @@ class Web3Service {
       userop.sender = acc.hexEip55;
 
       // determine the appropriate nonce
-      userop.nonce = await _entryPoint.getNonce(acc.hexEip55);
+      userop.nonce = await _entryPoint!.getNonce(acc.hexEip55);
 
       // if it's the first user op from this account, we need to deploy the account contract
       if (userop.nonce == BigInt.zero) {
         // construct the init code to deploy the account
-        userop.initCode = await _accountFactory.createAccountInitCode(
-          _credentials.address.hexEip55,
+        userop.initCode = await _accountFactory!.createAccountInitCode(
+          _credentials!.address.hexEip55,
           BigInt.zero,
         );
       }
@@ -634,18 +638,18 @@ class Web3Service {
       // set the appropriate call data for the transfer
       // we need to call account.execute which will call token.transfer
       userop.callData = dest.length > 1 && calldata.length > 1
-          ? _contractAccount.executeBatchCallData(
+          ? _contractAccount!.executeBatchCallData(
               dest,
               calldata,
             )
-          : _contractAccount.executeCallData(
+          : _contractAccount!.executeCallData(
               dest[0],
               BigInt.zero,
               calldata[0],
             );
 
       // set the appropriate gas fees based on network
-      final fees = await _gasPriceEstimator.estimate;
+      final fees = await _gasPriceEstimator!.estimate;
       if (fees == null) {
         throw Exception('unable to estimate fees');
       }
@@ -663,7 +667,7 @@ class Web3Service {
         PaymasterData? paymasterData;
         (paymasterData, paymasterErr) = await _getPaymasterData(
           userop,
-          _entryPoint.addr,
+          _entryPoint!.addr,
           'cw',
         );
 
@@ -674,7 +678,7 @@ class Web3Service {
         // if it's not the first user op, we should use an out of order paymaster signature
         (paymasterOOData, paymasterErr) = await _getPaymasterOOData(
           userop,
-          _entryPoint.addr,
+          _entryPoint!.addr,
           'cw',
         );
       }
@@ -700,10 +704,10 @@ class Web3Service {
       userop.callGasLimit = paymasterData.callGasLimit;
 
       // get the hash of the user op
-      final hash = await _entryPoint.getUserOpHash(userop);
+      final hash = await _entryPoint!.getUserOpHash(userop);
 
       // now we can sign the user op
-      userop.generateSignature(_credentials, hash);
+      userop.generateSignature(_credentials!, hash);
 
       return (bytesToHex(hash, include0x: true), userop);
     } catch (_) {
@@ -713,7 +717,7 @@ class Web3Service {
 
   /// makes a jsonrpc request from this wallet
   Future<SUJSONRPCResponse> _requestBundler(SUJSONRPCRequest body) async {
-    final rawResponse = await _bundlerRPC.post(
+    final rawResponse = await _bundlerRPC!.post(
       body: body,
     );
 
@@ -790,7 +794,7 @@ class Web3Service {
       // send the user op
       final (txHash, useropErr) = await _submitUserOp(
         userop,
-        _entryPoint.addr,
+        _entryPoint!.addr,
         data: data,
       );
       if (useropErr != null) {

--- a/lib/state/scan/logic.dart
+++ b/lib/state/scan/logic.dart
@@ -63,36 +63,37 @@ class ScanLogic extends WidgetsBindingObserver {
       }
 
       final config = await _config.getConfig(selectedAlias);
+      if (config.token.standard == "erc20") {
+        if (config.cards == null) {
+          throw Exception('No cards');
+        }
 
-      if (config.cards == null) {
-        throw Exception('No cards');
+        if (config.erc4337?.paymasterAddress == null) {
+          throw Exception('No paymaster');
+        }
+
+        await _web3.init(
+          config.token.standard,
+          config.node?.url,
+          config.ipfs?.url,
+          config.erc4337?.rpcUrl,
+          config.indexer?.url,
+          config.indexer?.ipfsUrl,
+          config.erc4337?.paymasterRPCUrl,
+          config.erc4337?.paymasterAddress!,
+          config.cards?.cardFactoryAddress,
+          config.erc4337?.accountFactoryAddress,
+          config.erc4337?.entrypointAddress,
+          config.token.address,
+          config.profile?.address,
+        );
+
+        _profileLogic.resetAll();
+
+        _state.setVendorAddress(_web3.account.hexEip55);
+
+        _profileLogic.loadProfile(account: _web3.account.hexEip55);
       }
-
-      if (config.erc4337.paymasterAddress == null) {
-        throw Exception('No paymaster');
-      }
-
-      await _web3.init(
-        config.node.url,
-        config.ipfs.url,
-        config.erc4337.rpcUrl,
-        config.indexer.url,
-        config.indexer.ipfsUrl,
-        config.erc4337.paymasterRPCUrl,
-        config.erc4337.paymasterAddress!,
-        config.cards!.cardFactoryAddress,
-        config.erc4337.accountFactoryAddress,
-        config.erc4337.entrypointAddress,
-        config.token.address,
-        config.profile.address,
-      );
-
-      _profileLogic.resetAll();
-
-      _state.setVendorAddress(_web3.account.hexEip55);
-
-      _profileLogic.loadProfile(account: _web3.account.hexEip55);
-
       _state.setConfig(config);
       _state.setConfigs(await _config.getConfigs());
 
@@ -368,7 +369,7 @@ class ScanLogic extends WidgetsBindingObserver {
         amount: amount,
         symbol: symbol,
         description: description,
-        link: '${config.scan.url}/tx/$txHash',
+        link: '${config.scan!.url}/tx/$txHash',
       );
 
       await _web3.waitForTxSuccess(txHash);


### PR DESCRIPTION
The `config` object contains many required fields related to EVM account abstraction and the citizenwallet indexer. The main effect of this PR is to make those fields nullable. This is helpful when configuring the app to handle other types of tokens.

There is some example code supporting POS sales with SEEDS tokens on the Telos chain. (Telos chain is eosio, not EVM).